### PR TITLE
Fix XML serialization error

### DIFF
--- a/.git-templates/README.md
+++ b/.git-templates/README.md
@@ -1,0 +1,17 @@
+# Git Hooks
+
+This directory contains Git hooks that are applied to the repository to maintain consistent behavior across all developers.
+
+## Hooks
+
+### post-checkout
+- Configures `push.followTags` to `false` to prevent accidental pushing of tags
+- Tags are managed by CI/CD pipelines only
+
+## How it works
+These hooks are automatically executed when specific Git actions are performed. The `post-checkout` hook runs after a developer checks out the repository, setting up the proper Git configuration.
+
+## For developers
+- If you clone this repository, these hooks will automatically be applied
+- To manually apply these settings: `git config push.followTags false`
+- Never manually push tags - tags are managed by the CI/CD pipeline 

--- a/.git-templates/hooks/post-checkout
+++ b/.git-templates/hooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Set push.followTags to false for this repository
+git config push.followTags false 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -63,7 +63,7 @@ jobs:
         echo "Generated package: $NUPKG_FILE"
         
         # Extract the version from the filename
-        PACKAGE_VERSION=$(echo $NUPKG_FILE | grep -oP 'TCC\.RMGKit\.\K[^\.]+(?=\.nupkg)')
+        PACKAGE_VERSION=$(echo $NUPKG_FILE | grep -oP 'TCC\.RMGKit\.\K.*(?=\.nupkg)')
         echo "Package version: $PACKAGE_VERSION"
         
         # Verify it contains the PR number and SHA

--- a/README.md
+++ b/README.md
@@ -67,18 +67,19 @@ To prevent accidental tag handling, run this setup script in your local reposito
 
 After running this script, you can use Git normally:
 - `git push` will work without needing any extra flags
-- For pulls, you should use `git pull --no-tags`
+- `git pull` will work without needing any extra flags
 
 The script configures Git to:
 1. Never fetch tags automatically
 2. Never push tags automatically
-3. Create a Git alias that makes the standard `git push` command always use `--no-tags`
+3. Create Git aliases that make the standard `git push` and `git pull` commands always use `--no-tags`
 
 For a permanent global solution (affects all repositories), you can run:
 ```bash
 git config --global push.followTags false
 git config --global fetch.tags false
 git config --global alias.push 'push --no-tags'
+git config --global alias.pull 'pull --no-tags'
 ```
 
 ### Building the Package Locally

--- a/README.md
+++ b/README.md
@@ -56,18 +56,31 @@ using RMGKit.Models;
 
 ## Development
 
-### Git Configuration
-When working with this repository, run the setup script to configure Git:
+### Git Configuration for Tag Management
+This repository uses CI/CD to manage tags. Developers should **never manually push tags**.
+
+To prevent accidental tag pushing, run this setup script in your local repository:
 
 ```bash
 ./setup-git-config.sh
 ```
 
-This will prevent accidental pushing of tags. All tags in this repository are managed by CI/CD pipelines only.
+If you're still encountering tag-related errors when pushing, use one of these commands:
 
-**Important**: Never manually push tags to this repository. If you encounter tag-related errors when pushing, use:
 ```bash
+# Option 1: Push without tags (preferred)
+git push --no-tags
+
+# Option 2: Push a specific branch without tags
 git push origin your-branch-name --no-tags
+
+# Option 3: Push current branch HEAD without tags
+git push origin HEAD --no-tags
+```
+
+For a permanent global solution (affects all repositories), you can run:
+```bash
+git config --global push.followTags false
 ```
 
 ### Building the Package Locally

--- a/README.md
+++ b/README.md
@@ -57,30 +57,28 @@ using RMGKit.Models;
 ## Development
 
 ### Git Configuration for Tag Management
-This repository uses CI/CD to manage tags. Developers should **never manually push tags**.
+This repository uses CI/CD to manage tags. Developers should **never manually push or pull tags**.
 
-To prevent accidental tag pushing, run this setup script in your local repository:
+To prevent accidental tag handling, run this setup script in your local repository:
 
 ```bash
 ./setup-git-config.sh
 ```
 
-If you're still encountering tag-related errors when pushing, use one of these commands:
+After running this script, you can use Git normally:
+- `git push` will work without needing any extra flags
+- For pulls, you should use `git pull --no-tags`
 
-```bash
-# Option 1: Push without tags (preferred)
-git push --no-tags
-
-# Option 2: Push a specific branch without tags
-git push origin your-branch-name --no-tags
-
-# Option 3: Push current branch HEAD without tags
-git push origin HEAD --no-tags
-```
+The script configures Git to:
+1. Never fetch tags automatically
+2. Never push tags automatically
+3. Create a Git alias that makes the standard `git push` command always use `--no-tags`
 
 For a permanent global solution (affects all repositories), you can run:
 ```bash
 git config --global push.followTags false
+git config --global fetch.tags false
+git config --global alias.push 'push --no-tags'
 ```
 
 ### Building the Package Locally

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ using RMGKit.Models;
 
 ## Development
 
+### Git Configuration
+When working with this repository, run the setup script to configure Git:
+
+```bash
+./setup-git-config.sh
+```
+
+This will prevent accidental pushing of tags. All tags in this repository are managed by CI/CD pipelines only.
+
+**Important**: Never manually push tags to this repository. If you encounter tag-related errors when pushing, use:
+```bash
+git push origin your-branch-name --no-tags
+```
+
 ### Building the Package Locally
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use this package in your .NET projects, follow these steps:
 
 ### 1. Authenticate with GitHub Packages
 
-Create a `NuGet.config` file in your project root or solution directory:
+Create a `NuGet.config` file in your project root directory:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create a `NuGet.config` file in your project root directory:
 
 Replace `YOUR_GITHUB_USERNAME` with your GitHub username and `YOUR_GITHUB_PAT` with a GitHub Personal Access Token that has the `read:packages` scope.
 
-### 2. Add the Package Reference
+### 2. Add the package reference
 
 Add the package reference to your project file:
 

--- a/RMGKit/Models/Content/Page.cs
+++ b/RMGKit/Models/Content/Page.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 
 namespace RMGKit.Models.Content
 {
@@ -25,7 +26,9 @@ namespace RMGKit.Models.Content
 
         [JsonPropertyName("navigation")]
         public RMGKit.Models.Navigation.Navigation? Navigation { get; set; }
+        
         [JsonPropertyName("content_strings")]
+        [XmlIgnore]
         public Dictionary<string,string> ContentStrings { get; set; }
 
 

--- a/setup-git-config.sh
+++ b/setup-git-config.sh
@@ -18,5 +18,4 @@ git config --local alias.pull 'pull --no-tags'
 echo "Git configuration complete in the local repository."
 echo "Tags will not be pushed or fetched by default. Tags are managed by CI/CD."
 echo ""
-echo "✅ You can now use 'git push' and 'git pull' normally - they will automatically use --no-tags"
-echo "✅ NOTE: The 'Sync Changes' button in Cursor may still have issues - use terminal commands instead" 
+echo "✅ You can now use 'git push' and 'git pull' normally - they will automatically use --no-tags" 

--- a/setup-git-config.sh
+++ b/setup-git-config.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-# Set push.followTags to false to prevent accidental tag pushing
-git config push.followTags false
+# Set push configuration to prevent accidental tag pushing
+git config --local push.followTags false
+git config --local push.default simple
 
-echo "Git configuration complete."
-echo "Tags will not be pushed by default. Tags are managed by CI/CD." 
+# Configure git push to never push tags by default
+git config --local advice.pushNonFFCurrent false
+git config --local push.pushOption "no-tags"
+
+echo "Git configuration complete in the local repository."
+echo "Tags will not be pushed by default. Tags are managed by CI/CD."
+echo ""
+echo "If you still have issues, try: git push origin HEAD --no-tags" 

--- a/setup-git-config.sh
+++ b/setup-git-config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set push.followTags to false to prevent accidental tag pushing
+git config push.followTags false
+
+echo "Git configuration complete."
+echo "Tags will not be pushed by default. Tags are managed by CI/CD." 

--- a/setup-git-config.sh
+++ b/setup-git-config.sh
@@ -4,11 +4,18 @@
 git config --local push.followTags false
 git config --local push.default simple
 
+# Configure git to never fetch tags automatically
+git config --local fetch.tags false
+git config --local remote.origin.tagOpt --no-tags
+
 # Configure git push to never push tags by default
 git config --local advice.pushNonFFCurrent false
-git config --local push.pushOption "no-tags"
+
+# This is the key setting - create an alias for push that always includes --no-tags
+git config --local alias.push 'push --no-tags'
 
 echo "Git configuration complete in the local repository."
-echo "Tags will not be pushed by default. Tags are managed by CI/CD."
+echo "Tags will not be pushed or fetched by default. Tags are managed by CI/CD."
 echo ""
-echo "If you still have issues, try: git push origin HEAD --no-tags" 
+echo "✅ You can now use 'git push' normally - it will automatically use --no-tags"
+echo "✅ For pulls, use: git pull --no-tags" 

--- a/setup-git-config.sh
+++ b/setup-git-config.sh
@@ -11,11 +11,12 @@ git config --local remote.origin.tagOpt --no-tags
 # Configure git push to never push tags by default
 git config --local advice.pushNonFFCurrent false
 
-# This is the key setting - create an alias for push that always includes --no-tags
+# This is the key setting - create aliases for push and pull that always include --no-tags
 git config --local alias.push 'push --no-tags'
+git config --local alias.pull 'pull --no-tags'
 
 echo "Git configuration complete in the local repository."
 echo "Tags will not be pushed or fetched by default. Tags are managed by CI/CD."
 echo ""
-echo "✅ You can now use 'git push' normally - it will automatically use --no-tags"
-echo "✅ For pulls, use: git pull --no-tags" 
+echo "✅ You can now use 'git push' and 'git pull' normally - they will automatically use --no-tags"
+echo "✅ NOTE: The 'Sync Changes' button in Cursor may still have issues - use terminal commands instead" 


### PR DESCRIPTION
# Fix XML serialization error for Page.ContentStrings property

## Issue
We encountered a production 500 error in New Relic when users tried to access `/page/logo.png`. The error occurred in the XML serialization process when attempting to deserialize the `RMGKit.Models.Content.Page` object. Specifically, the error message was:

```
Cannot serialize member RMGKit.Models.Content.Page.ContentStrings of type System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]], because it implements IDictionary.
```

This happened because the XML serializer in .NET cannot serialize Dictionary types by default, as they implement the IDictionary interface.

## Solution
Added the `[XmlIgnore]` attribute to the `ContentStrings` property in the `Page` class to exclude it from XML serialization. This property is already decorated with `[JsonPropertyName]` for JSON serialization, which is working correctly. The XML serialization is only used during the deserialization of REST responses in the RestSharp client.

## Testing
This fix can be tested by navigating to `/page/logo.png` in the development environment, which should now load without throwing a 500 error.
