### PR TITLE
Add timeout handling to RMGKit API calls

### DIFF
--- a/RMGKit/Service.cs
+++ b/RMGKit/Service.cs
@@ -217,7 +217,7 @@ namespace RMGKit
 
 			var options = new RestClientOptions(_url)
 			{
-				MaxTimeout = 10000, // 10 seconds timeout
+				Timeout = 10000, // 10 seconds timeout
 				ThrowOnAnyError = false,
 			};
 			var client = new RestClient(options);
@@ -276,7 +276,7 @@ namespace RMGKit
 
 			var options = new RestClientOptions(_url)
 			{
-				MaxTimeout = 10000, // 10 seconds timeout
+				Timeout = 10000, // 10 seconds timeout
 				ThrowOnAnyError = false,
 			};
 			var client = new RestClient(options);

--- a/RMGKit/Service.cs
+++ b/RMGKit/Service.cs
@@ -217,7 +217,7 @@ namespace RMGKit
 
 			var options = new RestClientOptions(_url)
 			{
-				Timeout = 10000, // 10 seconds timeout
+				Timeout = TimeSpan.FromSeconds(10), // 10 seconds timeout
 				ThrowOnAnyError = false,
 			};
 			var client = new RestClient(options);
@@ -276,7 +276,7 @@ namespace RMGKit
 
 			var options = new RestClientOptions(_url)
 			{
-				Timeout = 10000, // 10 seconds timeout
+				Timeout = TimeSpan.FromSeconds(10), // 10 seconds timeout
 				ThrowOnAnyError = false,
 			};
 			var client = new RestClient(options);

--- a/RMGKit/Service.cs
+++ b/RMGKit/Service.cs
@@ -215,7 +215,12 @@ namespace RMGKit
 			Dictionary<string, Object> _params = request.Parameters ?? new Dictionary<string, Object>();
 			Dictionary<string, string> _headers = DefaultRequestHeaders();
 
-			var client = new RestClient();
+			var options = new RestClientOptions(_url)
+			{
+				MaxTimeout = 10000, // 10 seconds timeout
+				ThrowOnAnyError = false,
+			};
+			var client = new RestClient(options);
 			var restRequest = new RestSharp.RestRequest(_url, Method.Get);
 
 			restRequest.AddHeaders(_headers);
@@ -252,7 +257,14 @@ namespace RMGKit
                     restRequest.AddOrUpdateHeader("X-Country", value.ToString());
                 }
             }
-			return await client.GetAsync<T?>(restRequest);
+			try {
+				return await client.GetAsync<T?>(restRequest);
+			} catch (System.Net.Http.HttpRequestException ex) when (ex.Message.Contains("GatewayTimeout")) {
+				// Log the timeout for debugging purposes
+				Console.WriteLine($"Gateway timeout occurred when calling {_url}");
+				// Return null or throw a more specific exception
+				return null;
+			}
 		}
 
 		// perform a get request
@@ -262,7 +274,12 @@ namespace RMGKit
 			Dictionary<string, Object> _params = request.Parameters ?? new Dictionary<string, Object>();
 			Dictionary<string, string> _headers = DefaultRequestHeaders();
 
-			var client = new RestClient();
+			var options = new RestClientOptions(_url)
+			{
+				MaxTimeout = 10000, // 10 seconds timeout
+				ThrowOnAnyError = false,
+			};
+			var client = new RestClient(options);
 			var restRequest = new RestSharp.RestRequest(_url, Method.Post);
 			 
 			restRequest.AddHeaders(_headers);
@@ -308,7 +325,14 @@ namespace RMGKit
                     restRequest.AddOrUpdateHeader("X-Country", value.ToString());
                 }
             } 
-			return await client.PostAsync<T?>(restRequest);
+			try {
+				return await client.PostAsync<T?>(restRequest);
+			} catch (System.Net.Http.HttpRequestException ex) when (ex.Message.Contains("GatewayTimeout")) {
+				// Log the timeout for debugging purposes
+				Console.WriteLine($"Gateway timeout occurred when calling {_url}");
+				// Return null or throw a more specific exception
+				return null;
+			}
 		}
 
         #endregion


### PR DESCRIPTION
# Add timeout handling to RMGKit API calls

This PR addresses 500 errors caused by GatewayTimeout exceptions in API calls. The changes include:

- Set a 10-second timeout for all RestClient requests to fail fast rather than letting requests hang
- Added exception handling specifically for GatewayTimeout errors
- Return null gracefully instead of propagating exceptions to the caller
- Added basic console logging when timeouts occur

These changes will prevent cascading failures when the Media endpoints are slow to respond, improving the user experience by handling timeouts gracefully instead of showing 500 errors.

The root cause of these needs to be investigated on the backend. Here's the endpoints:

- /v2/Media/GetMedia (when mediaID is numeric)
- /v2/Media/GetJWMedia (when mediaID is not numeric)

Here's the [error details in New Relic](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/NDg3Mjg4N3xBUE18QVBQTElDQVRJT058MTEwNjI4Mzk4MQ?account=4872887&duration=86400000&filters=selectedInstance%20IN%20%28%29&state=2845dd83-c870-10e4-79d3-5e71ba5ef5f0)
